### PR TITLE
[codex] Fix Codex bootstrap marketplace registration

### DIFF
--- a/docs/codex-bootstrap.md
+++ b/docs/codex-bootstrap.md
@@ -37,6 +37,7 @@ What it does:
 - Clones or updates `agent-skills` to `~/src/agent-skills` (override with `--repo-path`).
 - Registers this repo as a local Codex marketplace via `codex marketplace add "$REPO_PATH"`, keeping plugin paths relative to the repo root.
 - Symlinks all skills into `~/.codex/skills` (use `--copy` if you prefer copies). Conflicting entries are left untouched unless you pass `--force`.
+- Prints whether marketplace registration actually succeeded, was skipped, or failed, along with the manual `codex marketplace add` command when needed.
 
 Common options:
 

--- a/scripts/install-codex-assets.ps1
+++ b/scripts/install-codex-assets.ps1
@@ -51,6 +51,7 @@ function Normalize-Path {
 $RepoPath = Normalize-Path $RepoPath
 $CodexHome = Normalize-Path $CodexHome
 $MarketplaceName = $MarketplaceName
+$MarketplaceStatus = "not attempted"
 
 $SkillsRoot = Join-Path $CodexHome "skills"
 $CatalogPath = Join-Path $RepoPath "marketplaces/catalog.json"
@@ -82,6 +83,7 @@ function Clone-Or-UpdateRepo {
 function Register-Marketplace {
   $codexCmd = Get-Command codex -ErrorAction SilentlyContinue
   if (-not $codexCmd) {
+    $script:MarketplaceStatus = "not registered automatically (codex CLI not found)"
     Warn "codex CLI not found; skipping marketplace registration. Run manually: codex marketplace add `"$RepoPath`""
     return
   }
@@ -91,6 +93,7 @@ function Register-Marketplace {
   try {
     & codex marketplace add $RepoPath | Out-Null
     if ($LASTEXITCODE -eq 0) {
+      $script:MarketplaceStatus = "registered via ``codex marketplace add `"$RepoPath`"``"
       Log "Registered marketplace `"$MarketplaceName`" via codex marketplace add $RepoPath"
     }
     else {
@@ -98,6 +101,7 @@ function Register-Marketplace {
     }
   }
   catch {
+    $script:MarketplaceStatus = "not registered automatically (codex marketplace add failed)"
     Warn "failed to register marketplace via codex; run manually: CODEX_HOME=`"$CodexHome`" codex marketplace add `"$RepoPath`" ($($_.Exception.Message))"
   }
   finally {
@@ -255,11 +259,11 @@ function Main {
 
 Codex assets installed.
 - Repository path: $RepoPath
-- Marketplace: registered via `codex marketplace add "$RepoPath"`
+- Marketplace: $MarketplaceStatus
 - Skills directory: $SkillsRoot
 
 Next steps:
-- Restart Codex to pick up the marketplace change.
+- Restart Codex if marketplace registration succeeded.
 - Run "/plugins" or inspect available skills in your client.
 - If marketplace registration failed or Codex is not installed, run manually: CODEX_HOME="$CodexHome" codex marketplace add "$RepoPath"
 "@ | Write-Host

--- a/scripts/install-codex-assets.sh
+++ b/scripts/install-codex-assets.sh
@@ -14,6 +14,7 @@ CODEX_HOME="$CODEX_HOME_DEFAULT"
 MARKETPLACE_NAME="$MARKETPLACE_NAME_DEFAULT"
 SKILL_MODE="$SKILL_MODE_DEFAULT"
 FORCE=0
+MARKETPLACE_STATUS="not attempted"
 
 usage() {
   cat <<'EOF'
@@ -126,7 +127,7 @@ clone_or_update_repo() {
 
 cleanup_legacy_marketplace() {
   local marketplace_file="${LEGACY_AGENTS_HOME}/plugins/marketplace.json"
-  [[ -f "$marketplace_file" ]] || return
+  [[ -f "$marketplace_file" ]] || return 0
 
   python3 - "$marketplace_file" "$MARKETPLACE_NAME" <<'PY'
 import json
@@ -168,13 +169,16 @@ PY
 
 register_marketplace() {
   if ! command -v codex >/dev/null 2>&1; then
+    MARKETPLACE_STATUS="not registered automatically (codex CLI not found)"
     warn "codex CLI not found; skipping marketplace registration. Run manually: codex marketplace add \"${REPO_PATH}\""
     return
   fi
 
   if CODEX_HOME="${CODEX_HOME}" codex marketplace add "${REPO_PATH}"; then
+    MARKETPLACE_STATUS="registered via \`codex marketplace add \"${REPO_PATH}\"\`"
     log "Registered marketplace \"${MARKETPLACE_NAME}\" via codex marketplace add ${REPO_PATH}"
   else
+    MARKETPLACE_STATUS="not registered automatically (codex marketplace add failed)"
     warn "failed to register marketplace via codex; run manually: CODEX_HOME=\"${CODEX_HOME}\" codex marketplace add \"${REPO_PATH}\""
   fi
 }
@@ -268,11 +272,11 @@ main() {
 
 Codex assets installed.
 - Repository path: ${REPO_PATH}
-- Marketplace: registered via \`codex marketplace add "${REPO_PATH}"\`
+- Marketplace: ${MARKETPLACE_STATUS}
 - Skills directory: ${SKILLS_ROOT}
 
 Next steps:
-- Restart Codex to pick up the marketplace change.
+- Restart Codex if marketplace registration succeeded.
 - Run "/plugins" or inspect available skills in your client.
 - If marketplace registration failed or Codex is not installed, run manually: CODEX_HOME="${CODEX_HOME}" codex marketplace add "${REPO_PATH}"
 EOF


### PR DESCRIPTION
## Summary

Fix the Codex bootstrap installer so it reaches marketplace registration when legacy marketplace metadata is absent, and report marketplace registration status accurately in the install summary.

## Root Cause

`scripts/install-codex-assets.sh` runs with `set -euo pipefail`, but `cleanup_legacy_marketplace` treated a missing `~/.agents/plugins/marketplace.json` file as a bare `return`, which propagated a non-zero status and exited the installer before `codex marketplace add` or skill installation ran.

## Changes

- treat a missing legacy marketplace file as a no-op in the bash installer
- track marketplace registration status in both installers
- print the actual marketplace registration outcome in the final summary
- document that the installer reports whether automatic registration succeeded or needs a manual follow-up

## Validation

- `bash -n scripts/install-codex-assets.sh`
- ran `scripts/install-codex-assets.sh` against a temporary git repo built from the working tree with a stub `codex` that exits `0`; confirmed marketplace registration and skill linking completed
- ran the same installer flow with a stub `codex` that exits `1`; confirmed the installer continued, linked skills, and reported that marketplace registration was not completed automatically

Closes #16.
