### PR TITLE
[codex] strengthen rails 37signals coverage

### DIFF
--- a/.agents/skills/37signals-kamal
+++ b/.agents/skills/37signals-kamal
@@ -1,0 +1,1 @@
+../../plugins/rails-37signals-patterns/skills/37signals-kamal

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,12 +10,13 @@
     {
       "name": "rails-37signals-patterns",
       "source": "./plugins/rails-37signals-patterns",
-      "description": "Focused 37signals-style Rails specialists for models, controllers, Hotwire, jobs, testing, and related application patterns.",
+      "description": "Focused 37signals-style Rails specialists for models, controllers, Hotwire, Kamal deployment, jobs, testing, and related application patterns.",
       "category": "development",
       "tags": [
         "rails",
         "37signals",
         "hotwire",
+        "kamal",
         "patterns",
         "developer-tools"
       ]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ agent-skills/
 
 ### Rails 37signals Patterns
 
-The `plugins/rails-37signals-patterns/skills/37signals-*` skills cover focused Rails patterns and conventions inspired by 37signals-style applications. Across the set, the defaults lean toward rich models, CRUD resources, Hotwire, Solid Queue, explicit `Current.account` scoping, UUID-backed schemas, and Minitest with fixtures.
+The `plugins/rails-37signals-patterns/skills/37signals-*` skills cover focused Rails patterns and conventions inspired by 37signals-style applications. Across the set, the defaults lean toward rich models, CRUD resources, Hotwire, Solid Queue, Kamal-based deployment, explicit tenancy choices, UUID-backed schemas, and Minitest with fixtures.
 
 **Architecture and workflow**
 
@@ -75,6 +75,7 @@ The `plugins/rails-37signals-patterns/skills/37signals-*` skills cover focused R
 - [`37signals-caching`](plugins/rails-37signals-patterns/skills/37signals-caching/SKILL.md) — HTTP caching, ETags, `fresh_when`, `stale?`, and fragment caching.
 - [`37signals-crud`](plugins/rails-37signals-patterns/skills/37signals-crud/SKILL.md) — RESTful controllers built around the “everything is CRUD” philosophy.
 - [`37signals-events`](plugins/rails-37signals-patterns/skills/37signals-events/SKILL.md) — event tracking, activity feeds, and webhook-friendly event models.
+- [`37signals-kamal`](plugins/rails-37signals-patterns/skills/37signals-kamal/SKILL.md) — Kamal deployment, roles, hooks, secrets, accessories, and deploy-safe Rails runtime operations.
 - [`37signals-jobs`](plugins/rails-37signals-patterns/skills/37signals-jobs/SKILL.md) — shallow background jobs and async workflows using Solid Queue.
 - [`37signals-mailer`](plugins/rails-37signals-patterns/skills/37signals-mailer/SKILL.md) — minimal Action Mailer patterns and bundled notifications.
 - [`37signals-stimulus`](plugins/rails-37signals-patterns/skills/37signals-stimulus/SKILL.md) — focused Stimulus controllers for progressive enhancement.
@@ -87,8 +88,8 @@ These specialist skills preserve source metadata in their frontmatter and were a
 
 The `plugins/rails-37signals-workflows/skills/rails-37signals-*` folders are standalone workflow skills for common Rails jobs, not just aliases. Each one includes an `agents/openai.yaml` file plus a focused `references/` set.
 
-- [`rails-37signals-implement`](plugins/rails-37signals-workflows/skills/rails-37signals-implement/SKILL.md) — end-to-end feature implementation in dependency order. See `references/conventions.md` and `references/implementation-workflow.md`.
-- [`rails-37signals-refactor`](plugins/rails-37signals-workflows/skills/rails-37signals-refactor/SKILL.md) — incremental, behavior-preserving refactors toward 37signals conventions. See `references/conventions.md` and `references/refactoring-guide.md`.
+- [`rails-37signals-implement`](plugins/rails-37signals-workflows/skills/rails-37signals-implement/SKILL.md) — end-to-end feature implementation in dependency order, including tenancy and deploy/runtime checks. See `references/conventions.md` and `references/implementation-workflow.md`.
+- [`rails-37signals-refactor`](plugins/rails-37signals-workflows/skills/rails-37signals-refactor/SKILL.md) — incremental, behavior-preserving refactors toward 37signals conventions, including tenancy cleanup and runtime alignment. See `references/conventions.md` and `references/refactoring-guide.md`.
 - [`rails-37signals-review`](plugins/rails-37signals-workflows/skills/rails-37signals-review/SKILL.md) — code review and architecture auditing for 37signals-style Rails codebases. See `references/conventions.md` and `references/review-checklist.md`.
 
 ### Fizzy

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,4 @@
 #!/usr/bin/env pwsh
-$ErrorActionPreference = "Stop"
 
 param(
   [string]$RepoPath = $(if ($env:AGENT_SKILLS_REPO_PATH) { $env:AGENT_SKILLS_REPO_PATH } else { "$HOME/src/agent-skills" }),
@@ -12,6 +11,8 @@ param(
   [switch]$Force,
   [switch]$Help
 )
+
+$ErrorActionPreference = "Stop"
 
 $RepoOwner = "joshyorko"
 $RepoName = "agent-skills"

--- a/marketplaces/catalog.json
+++ b/marketplaces/catalog.json
@@ -14,11 +14,12 @@
       "name": "rails-37signals-patterns",
       "category": "Developer Tools",
       "claude_category": "development",
-      "description": "Focused 37signals-style Rails specialists for models, controllers, Hotwire, jobs, testing, and related application patterns.",
+      "description": "Focused 37signals-style Rails specialists for models, controllers, Hotwire, Kamal deployment, jobs, testing, and related application patterns.",
       "tags": [
         "rails",
         "37signals",
         "hotwire",
+        "kamal",
         "patterns",
         "developer-tools"
       ]

--- a/plugins/rails-37signals-patterns/.claude-plugin/plugin.json
+++ b/plugins/rails-37signals-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rails-37signals-patterns",
   "version": "0.1.0",
-  "description": "Focused 37signals-style Rails skills for models, controllers, Hotwire, jobs, testing, and related architecture patterns.",
+  "description": "Focused 37signals-style Rails skills for models, controllers, Hotwire, Kamal deployment, jobs, testing, and related architecture patterns.",
   "author": {
     "name": "Josh Yorko",
     "email": "joshua.yorko@gmail.com",
@@ -14,6 +14,7 @@
     "rails",
     "37signals",
     "hotwire",
+    "kamal",
     "patterns",
     "skills"
   ]

--- a/plugins/rails-37signals-patterns/.codex-plugin/plugin.json
+++ b/plugins/rails-37signals-patterns/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rails-37signals-patterns",
   "version": "0.1.0",
-  "description": "Focused 37signals-style Rails skills for models, controllers, Hotwire, jobs, testing, and related architecture patterns.",
+  "description": "Focused 37signals-style Rails skills for models, controllers, Hotwire, Kamal deployment, jobs, testing, and related architecture patterns.",
   "author": {
     "name": "Josh Yorko",
     "email": "joshua.yorko@gmail.com",
@@ -14,6 +14,7 @@
     "rails",
     "37signals",
     "hotwire",
+    "kamal",
     "patterns",
     "skills"
   ],
@@ -21,7 +22,7 @@
   "interface": {
     "displayName": "Rails 37signals Patterns",
     "shortDescription": "Focused Rails pattern skills inspired by 37signals.",
-    "longDescription": "Focused Rails specialists for CRUD, models, Hotwire, caching, jobs, multi-tenancy, and related 37signals-style application design.",
+    "longDescription": "Focused Rails specialists for CRUD, models, Hotwire, Kamal deployment, caching, jobs, multi-tenancy, and related 37signals-style application design.",
     "developerName": "Josh Yorko",
     "category": "Developer Tools",
     "capabilities": [
@@ -34,7 +35,8 @@
     "defaultPrompt": [
       "Implement this Rails model using 37signals patterns.",
       "Refactor this controller toward RESTful Rails conventions.",
-      "Review this Hotwire feature for 37signals-style tradeoffs."
+      "Review this Hotwire feature for 37signals-style tradeoffs.",
+      "Set up or fix Kamal deployment for this Rails app."
     ],
     "brandColor": "#9A3412"
   }

--- a/plugins/rails-37signals-patterns/skills/37signals-active-record-tenanted/SKILL.md
+++ b/plugins/rails-37signals-patterns/skills/37signals-active-record-tenanted/SKILL.md
@@ -13,88 +13,75 @@ metadata:
   source: activerecord-tenanted
   source_repo: basecamp/activerecord-tenanted
   source_ref: main
-  source_path: GUIDE.md
+  source_path: README.md, GUIDE.md
   compatibility: Ruby 3.3+, Rails 8.2+, sqlite3
 ---
 
 # 37signals Active Record Tenanted
 
-You are an expert Rails developer specializing in separate-database multi-tenancy with Active Record Tenanted.
+Use this skill when the app should isolate tenant data in separate databases and let Rails carry the tenant context for you.
 
-## Your role
-- You set up and extend `activerecord-tenanted` with the smallest safe Rails changes.
-- You keep tenant isolation in the framework layer instead of scattering `account_id` filters through the app.
-- You preserve normal Rails conventions so feature code feels single-tenant inside a tenant context.
-- Your output: tenant-safe Rails code, configuration, migrations, and tests.
+This is the database-per-tenant path. Use `37signals-multi-tenant` instead when the app intentionally keeps all tenants in one shared database and scopes through `Current.account` plus `account_id`.
 
-## Core philosophy
+## Core approach
 
-**One tenant context. One isolated database. Rails should do the switching for you.**
+- Tenanting lives in the framework layer, not in ad hoc query scopes.
+- A tenant key resolves to a tenant-specific database name or path.
+- Tenanted code should feel single-tenant inside the current tenant context.
+- Shared/global data should stay explicitly outside the tenanted connection.
 
-### Prefer this
+Prefer this:
+
 ```ruby
-# app/models/application_record.rb
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
   tenanted
 end
 
-# config/initializers/active_record_tenanted.rb
 Rails.application.configure do
-  config.active_record_tenanted.tenant_resolver = ->(request) { request.path_parameters[:account_id] }
-end
-
-ApplicationRecord.with_tenant("acme") do
-  Project.create!(name: "Roadmap")
+  config.active_record_tenanted.connection_class = "ApplicationRecord"
+  config.active_record_tenanted.tenant_resolver = ->(request) { request.subdomain }
 end
 ```
 
-### Not this
+Not this:
+
 ```ruby
-# ❌ Don't rely on remembering account scoping in every query
 class Project < ApplicationRecord
   scope :for_account, ->(account_id) { where(account_id: account_id) }
 end
-
-def create
-  Project.create!(project_params.merge(account_id: params[:account_id]))
-end
 ```
 
-## When to use this skill
+## Repo decision rule
 
-Use this skill when the app should isolate each tenant in its own database or database file, especially when:
-- adopting `activerecord-tenanted`
-- converting a commingled Rails app to per-tenant databases
-- configuring tenant-aware `database.yml`
-- wiring request, job, cache, or cable tenant context
-- replacing `account_id`-everywhere scoping with framework-level tenant isolation
+Choose one tenancy model per feature area and stay consistent:
 
-Use `37signals-multi-tenant` instead when the app intentionally keeps all tenants in one shared database and scopes with `Current.account` plus `account_id`.
+- Shared DB: `Current.account`, `account_id`, explicit account scoping, normal shared tables.
+- Separate DB: `tenanted`, `with_tenant`, separate tenant databases, explicit shared/global models outside the tenanted connection.
 
-## Project knowledge
+Hybrid apps are possible, but the boundary must be explicit:
 
-**Default gem posture**
-- built on Rails horizontal sharding APIs
-- `sqlite3` is the fully supported adapter today
-- tenant context is required for database access
-- Rails integrations carry tenant context into jobs, caches, cable, and related subsystems
+- shared models inherit from a non-tenanted abstract class
+- tenant-owned models inherit from the tenanted connection class
+- jobs, caches, broadcasts, and scripts must know which side they are operating on
 
-**Important concepts**
-- a tenant ID identifies the tenant-specific database
-- `ApplicationRecord.current_tenant` is the current execution context
-- `ApplicationRecord.with_tenant("acme") { ... }` scopes all Active Record work inside the block
-- querying a tenanted model without a tenant context should raise instead of leaking data
+## Current upstream posture
 
-## Installation and baseline setup
+- `sqlite3` is the only fully supported adapter today.
+- The gem is built on Rails horizontal sharding APIs.
+- Access without a tenant context should raise `ActiveRecord::Tenanted::NoTenantError`.
+- The upstream GUIDE is still a work in progress, so some framework integrations should be treated as provisional and verified against the gem version in use.
 
-### 1. Add the gem
+## Baseline setup
+
+1. Add the gem.
+
 ```ruby
-# Gemfile
 gem "activerecord-tenanted"
 ```
 
-### 2. Tenant the abstract base class
+2. Tenant the abstract base class.
+
 ```ruby
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
@@ -102,7 +89,8 @@ class ApplicationRecord < ActiveRecord::Base
 end
 ```
 
-### 3. Mark the database config as tenanted
+3. Mark the tenant database configuration as tenanted.
+
 ```yaml
 production:
   primary:
@@ -112,7 +100,8 @@ production:
     max_connection_pools: 20
 ```
 
-### 4. Configure tenant resolution
+4. Configure the connection class and resolver.
+
 ```ruby
 Rails.application.configure do
   config.active_record_tenanted.connection_class = "ApplicationRecord"
@@ -120,17 +109,30 @@ Rails.application.configure do
 end
 ```
 
-If the app uses URL-based account routing instead of subdomains, prefer an explicit resolver:
+5. If only part of the app is tenant-isolated, use a separate abstract class.
 
 ```ruby
-Rails.application.configure do
-  config.active_record_tenanted.tenant_resolver = ->(request) { request.path_parameters[:account_id] }
+class TenantedApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+  tenanted "tenant_db"
 end
 ```
 
-## Implementation patterns
+## Tenant key guidance
 
-### Pattern 1: Request-scoped tenant context
+Pick one canonical tenant key and use it consistently in the resolver, lifecycle code, and provisioning flow. In practice this is usually a slug or subdomain, not an internal numeric ID.
+
+- Normalize case and whitespace once.
+- Validate characters based on the backing database naming/path rules.
+- Do not let arbitrary user input become a database name without normalization and validation.
+- If routes expose `account_id`, make sure it resolves to the canonical tenant key instead of using raw path data blindly.
+
+## Runtime patterns
+
+### Requests
+
+Inside a resolved request, controllers should read like ordinary Rails controllers:
+
 ```ruby
 class ProjectsController < ApplicationController
   def index
@@ -139,60 +141,51 @@ class ProjectsController < ApplicationController
 end
 ```
 
-Inside a resolved tenant request, the controller should be able to act like a normal single-tenant Rails controller. Avoid manually repeating tenant filters unless the design truly requires mixed shared and tenanted data.
+### Scripts, console, and one-off work
 
-### Pattern 2: Explicit tenant context outside requests
+Outside a request, always set the tenant explicitly:
+
 ```ruby
 ApplicationRecord.with_tenant(account.slug) do
   ProjectImporter.new.call
 end
 ```
 
-Use explicit tenant blocks in:
-- console tasks
-- scripts
-- data backfills
-- one-off maintenance
-- tests that exercise tenant switching directly
+Use explicit tenant blocks in console tasks, data backfills, repair scripts, and maintenance commands.
 
-### Pattern 3: Alternate tenanted connection class
-```ruby
-class TenantedApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-  tenanted "tenant_db"
-end
+### Jobs, caches, and broadcasts
 
-Rails.application.configure do
-  config.active_record_tenanted.connection_class = "TenantedApplicationRecord"
-end
+Do not copy shared-database `Current.account` examples into a database-per-tenant app.
+
+- Jobs should restore the tenant context before touching tenanted models.
+- Cache keys, stream names, and broadcast channels should include tenant identity when they escape the database boundary.
+- Be cautious with direct `Rails.cache` access and global cache namespaces; verify how the installed gem version integrates with fragment caching and cache key derivation.
+- Treat Action Cable, Turbo streams, and Active Job integration as something to verify against the gem version in use, not as magic you can assume blindly.
+
+## Tenant lifecycle
+
+Separate-database tenancy is not just query scoping. You need a lifecycle plan:
+
+- tenant creation: provision the tenant database before routing traffic there
+- tenant migration: know whether you are migrating one tenant or all tenants
+- tenant archival or deletion: remove access first, then archive or drop the tenant database intentionally
+- tenant bootstrap: seed required tenant-owned records after provisioning
+
+Be explicit about database tasks in scripts and docs:
+
+```bash
+bundle add activerecord-tenanted
+bin/rails db:migrate
+ARTENANT=acme bin/rails db:migrate:primary
+bin/rails test
+bin/rails console
 ```
 
-Use this when only part of the app is tenant-isolated and other models stay on an untenanted primary database.
-
-## Safety rules
-
-### Always
-- require a tenant context before touching tenanted models
-- keep tenant resolution in one place
-- let Rails integrations carry tenant context through jobs, caching, cable, and rendering
-- validate tenant identifiers if they come from user-controlled input
-- keep shared/global data explicitly separate from tenant data
-
-### Ask first
-- using MySQL or PostgreSQL as the tenanted adapter
-- mixing commingled shared tables with tenant databases
-- custom cross-tenant admin/reporting features
-- path-based routing that needs non-trivial tenant lookup
-
-### Never
-- query tenanted models with no tenant set
-- silently fall back to a default tenant for normal requests
-- rebuild tenant isolation with ad hoc `where(account_id: ...)` filters everywhere
-- assume record IDs are globally unique across tenants
+If a tenant database is missing required migrations, treat that as an operational problem to fix, not something to paper over with a fallback tenant.
 
 ## Testing guidance
 
-Test the tenant boundary, not just happy-path CRUD.
+Test the tenant boundary directly:
 
 ```ruby
 test "requires a tenant context" do
@@ -212,31 +205,38 @@ end
 ```
 
 Also cover:
-- tenant resolver behavior
-- background jobs restoring tenant context
-- cache keys or broadcast streams carrying tenant identity when relevant
-- tenant creation/migration flows for new accounts
 
-## Commands you can use
+- tenant resolver behavior in request tests
+- job execution restoring the correct tenant
+- provisioning and migration flows for new tenants
+- any test helper or fixture behavior that sets a default tenant for convenience
+- cleanup for tenant databases created during tests
 
-```bash
-bundle add activerecord-tenanted
-bin/rails db:migrate
-ARTENANT=acme bin/rails db:migrate:primary
-bin/rails test
-bin/rails console
-```
+## Boundaries
+
+### Always
+
+- Keep tenant resolution in one place.
+- Require an explicit tenant context before touching tenanted models.
+- Keep shared/global data separate from tenant-owned data.
+- Verify framework integrations that cross request boundaries.
+
+### Ask first
+
+- Using MySQL or PostgreSQL as the tenanted adapter.
+- Cross-tenant reporting or admin flows.
+- Hybrid designs where some models are shared and some are tenanted.
+- Custom connection management beyond the gem defaults.
+
+### Never
+
+- Fall back silently to a default tenant in normal app flow.
+- Rebuild tenant isolation with ad hoc `where(account_id: ...)` filters everywhere.
+- Assume IDs, cache entries, or stream names are globally unique across tenants.
 
 ## Related skills
 
 - `37signals-multi-tenant` for shared-database account scoping
-- `37signals-migration` for schema and database changes
-- `37signals-model` for model boundaries inside a tenant
-- `37signals-jobs` for tenant-aware background work
-- `37signals-caching` and `37signals-turbo` for tenant-aware UI/runtime behavior
-
-## Boundaries
-
-- ✅ **Always do:** prefer framework-enforced isolation, keep tenant resolution explicit, test for missing-tenant failures, and preserve normal Rails conventions inside the tenant context
-- ⚠️ **Ask first:** before introducing cross-tenant queries, custom connection management, or unsupported adapter assumptions
-- 🚫 **Never do:** write code that can read or transmit tenant data outside a well-defined tenant context
+- `37signals-migration` for schema and database lifecycle changes
+- `37signals-model` for boundaries inside tenanted models
+- `37signals-kamal` for deploy, secrets, roles, and runtime operations

--- a/plugins/rails-37signals-patterns/skills/37signals-active-record-tenanted/agents/openai.yaml
+++ b/plugins/rails-37signals-patterns/skills/37signals-active-record-tenanted/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "37signals Active Record Tenanted"
+  short_description: "Implements separate-database multi-tenancy with Active Record Tenanted using tenant-aware Rails conventions, resolver configuration, and safety guardrails."
+  default_prompt: "Use $37signals-active-record-tenanted when adding activerecord-tenanted, isolating each tenant in its own database, or adapting a Rails app to database-per-tenant architecture."
+
+policy:
+  allow_implicit_invocation: true

--- a/plugins/rails-37signals-patterns/skills/37signals-implement/SKILL.md
+++ b/plugins/rails-37signals-patterns/skills/37signals-implement/SKILL.md
@@ -44,10 +44,12 @@ Historical upstream examples refer to generic `@...-agent` names. In this repo, 
    - API endpoint
 2. Break the work into layers.
    - data and migrations
+   - tenancy model and runtime ownership
    - models and concerns
    - controllers and routes
    - views, Turbo, and Stimulus
    - jobs, mailers, and events
+   - deploy and operations
    - tests
 3. Invoke the right specialist skills in dependency order.
 4. Re-check the combined implementation for account scoping, naming consistency, and user-visible behavior.
@@ -56,19 +58,22 @@ Historical upstream examples refer to generic `@...-agent` names. In this repo, 
 ## Delegation Guide
 
 - `$37signals-migration` for schema and data changes.
+- `$37signals-active-record-tenanted` or `$37signals-multi-tenant` for choosing the tenancy model and enforcing it consistently.
 - `$37signals-model` and `$37signals-concerns` for core domain logic.
 - `$37signals-crud` for controller and route shape.
 - `$37signals-turbo` and `$37signals-stimulus` for interaction and real-time UX.
 - `$37signals-jobs`, `$37signals-mailer`, and `$37signals-events` for async and notification behavior.
 - `$37signals-api` for JSON endpoints.
+- `$37signals-kamal` for deploy config, runtime roles, and shipping changes safely.
 - `$37signals-test` for final coverage.
 
 ## Implementation Rules
 
 - Prefer resources over custom verbs.
 - Keep business logic in models and concerns.
-- Maintain explicit account scoping.
+- Maintain the chosen tenancy model consistently.
 - Use background jobs for expensive side effects.
+- Include deploy/runtime changes when the feature changes startup, workers, dependencies, or secrets.
 - Add tests with the implementation, not after the fact.
 
 ## Boundaries

--- a/plugins/rails-37signals-patterns/skills/37signals-kamal/SKILL.md
+++ b/plugins/rails-37signals-patterns/skills/37signals-kamal/SKILL.md
@@ -45,6 +45,7 @@ Kamal is the concrete deployment layer missing from the rest of the Rails / 37si
    - web only, or web plus workers
    - accessories needed, or externally managed services
    - single destination, or staging plus production
+   - proxied roles, non-proxy roles, and rollout controls
 2. Make the app boot cleanly in a container first.
 3. Add or tighten Kamal config.
 4. Verify healthchecks, secrets, and role commands.
@@ -61,17 +62,22 @@ Kamal is the concrete deployment layer missing from the rest of the Rails / 37si
 
 ### Healthchecks
 
-- Let Kamal switch traffic only after the new container responds cleanly.
+- Distinguish proxied and non-proxy roles.
+- Proxied roles are checked through `proxy.healthcheck`.
+- Non-proxy roles should use Docker healthchecks such as `health-cmd` under container options.
 - Use the app’s real readiness endpoint, typically `/up` unless the app needs a different check.
-- If a worker or accessory needs a custom health command, define it directly in config.
+- Kamal rollout safety also depends on `deploy_timeout`, `drain_timeout`, and `readiness_delay`.
+- Rails 8 Docker defaults assume Thruster in front of Puma, so the proxy checks port `80` by default. If the app still exposes Puma directly on `3000`, set `proxy.app_port: 3000`.
 
 ### Secrets and environment
 
 - Keep secrets in `.kamal/secrets`, `.kamal/secrets-common`, or destination-specific variants.
 - Prefer credentials-backed secret fetching when the app already keeps deploy secrets in Rails credentials.
+- Keep `env.clear` and `env.secret` explicit instead of relying on ambient shell state.
 - Pass only the needed variables under `env`.
 - Keep clear values and secret values distinct.
 - Do not commit secrets or rely on ad hoc shell state that the deploy host cannot reproduce.
+- Remember that values from `.kamal/secrets*` are for Kamal secret resolution, not a general-purpose source for `deploy.yml` ERB or arbitrary ENV lookups.
 
 Example:
 
@@ -84,12 +90,15 @@ KAMAL_REGISTRY_PASSWORD=$(rails credentials:fetch kamal.registry_password)
 - Use accessories for deploy-managed dependencies that belong with the app.
 - Keep them separate from the main app roles.
 - Be explicit about ports, volumes, and env so replacement and recovery are predictable.
+- Accessories have their own lifecycle: they are not updated as part of normal app deploys and they do not get zero-downtime deployment behavior.
 
 ### Hooks
 
 - Use hooks for narrow operational tasks, not for hiding application behavior.
+- Store them under `.kamal/hooks` with extensionless filenames that exactly match the hook name.
 - Fail fast on non-zero exit status.
 - Prefer hooks for deploy notifications, preflight checks, or controlled maintenance steps.
+- Use the available `KAMAL_*` variables when you need deploy audit context in a hook.
 
 ### Builders and registry
 
@@ -98,12 +107,18 @@ KAMAL_REGISTRY_PASSWORD=$(rails credentials:fetch kamal.registry_password)
 - For simple deploys, local-registry flows are a valid default; move to a remote registry when scale or topology actually requires it.
 - Keep registry auth and build secrets out of the Dockerfile and out of git.
 
+### Rollout controls
+
+- Use `boot.limit`, `boot.wait`, and `boot.parallel_roles` deliberately on multi-host or multi-role deploys.
+- Slow boots and sensitive migrations should change rollout settings explicitly instead of hoping the defaults fit.
+
 ## Rails-specific guidance
 
 - Pair deploy changes with app-layer changes that affect startup, migrations, assets, or worker shutdown.
 - Treat migrations as deploy choreography, not just schema edits.
 - If a Rails change adds a new long-running process, background queue, or extra dependency, update Kamal roles and accessories in the same change.
-- Keep worker shutdown behavior in mind for Solid Queue or other job processors.
+- Keep worker shutdown behavior in mind for Solid Queue or other job processors; Kamal’s default container shutdown window is short enough that long-running jobs should be interruption-safe.
+- If the app does long-running Active Job work, evaluate `ActiveJob::Continuable` or a similar resumable design instead of assuming workers will always finish before shutdown.
 
 ## Commands you can use
 

--- a/plugins/rails-37signals-patterns/skills/37signals-kamal/SKILL.md
+++ b/plugins/rails-37signals-patterns/skills/37signals-kamal/SKILL.md
@@ -68,9 +68,16 @@ Kamal is the concrete deployment layer missing from the rest of the Rails / 37si
 ### Secrets and environment
 
 - Keep secrets in `.kamal/secrets`, `.kamal/secrets-common`, or destination-specific variants.
+- Prefer credentials-backed secret fetching when the app already keeps deploy secrets in Rails credentials.
 - Pass only the needed variables under `env`.
 - Keep clear values and secret values distinct.
 - Do not commit secrets or rely on ad hoc shell state that the deploy host cannot reproduce.
+
+Example:
+
+```sh
+KAMAL_REGISTRY_PASSWORD=$(rails credentials:fetch kamal.registry_password)
+```
 
 ### Accessories
 
@@ -88,6 +95,7 @@ Kamal is the concrete deployment layer missing from the rest of the Rails / 37si
 
 - Be explicit about target architecture when local and server architectures differ.
 - Use a remote builder when local builds are too slow or incompatible.
+- For simple deploys, local-registry flows are a valid default; move to a remote registry when scale or topology actually requires it.
 - Keep registry auth and build secrets out of the Dockerfile and out of git.
 
 ## Rails-specific guidance

--- a/plugins/rails-37signals-patterns/skills/37signals-kamal/SKILL.md
+++ b/plugins/rails-37signals-patterns/skills/37signals-kamal/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: 37signals-kamal
+description: >-
+  Deploys Rails applications with Kamal using roles, accessories, hooks,
+  secrets, and deploy-safe operational patterns aligned with modern Rails and
+  37signals-style infrastructure choices. Use when setting up Kamal, editing
+  deploy config, shipping Rails changes, or debugging deploy/runtime issues.
+license: MIT
+metadata:
+  author: Josh Yorko
+  version: "1.0"
+  source: Kamal docs
+  source_repo: basecamp/kamal
+  source_ref: main
+  source_path: kamal-deploy.org/docs
+  compatibility: Ruby 3.3+, Rails 8.x, Kamal 2
+---
+
+# 37signals Kamal
+
+Use this skill for Rails deployment and runtime operations with Kamal.
+
+Kamal is the concrete deployment layer missing from the rest of the Rails / 37signals skill set. Keep application architecture in the other skills; use this one for `config/deploy.yml`, `.kamal/secrets`, roles, accessories, hooks, builders, healthchecks, and deploy-safe operational changes.
+
+## Core approach
+
+- Keep infrastructure boring: one Rails app image, explicit roles, few moving parts.
+- Prefer Kamal defaults unless there is a proven need to customize them.
+- Treat deployment work as part of the feature, not as an afterthought.
+- Keep secrets out of git and deployment behavior reproducible from repo-owned config.
+
+## What this skill owns
+
+- `config/deploy.yml` and destination-specific Kamal config
+- `.kamal/secrets*` conventions and environment wiring
+- web/job role layout
+- accessories for stateful dependencies
+- hooks for deploy reporting or preflight checks
+- builder and registry decisions
+- deploy, rollback, and runtime debugging commands
+
+## Default workflow
+
+1. Confirm the runtime shape.
+   - web only, or web plus workers
+   - accessories needed, or externally managed services
+   - single destination, or staging plus production
+2. Make the app boot cleanly in a container first.
+3. Add or tighten Kamal config.
+4. Verify healthchecks, secrets, and role commands.
+5. Choose the smallest safe deploy command.
+6. Leave behind a repeatable operational path, not tribal knowledge.
+
+## Default patterns
+
+### Roles
+
+- Put HTTP traffic on the primary web role.
+- Give long-running job processors their own role when shutdown behavior or concurrency differs from web.
+- Keep role commands explicit instead of overloading one container with unrelated entrypoints.
+
+### Healthchecks
+
+- Let Kamal switch traffic only after the new container responds cleanly.
+- Use the app’s real readiness endpoint, typically `/up` unless the app needs a different check.
+- If a worker or accessory needs a custom health command, define it directly in config.
+
+### Secrets and environment
+
+- Keep secrets in `.kamal/secrets`, `.kamal/secrets-common`, or destination-specific variants.
+- Pass only the needed variables under `env`.
+- Keep clear values and secret values distinct.
+- Do not commit secrets or rely on ad hoc shell state that the deploy host cannot reproduce.
+
+### Accessories
+
+- Use accessories for deploy-managed dependencies that belong with the app.
+- Keep them separate from the main app roles.
+- Be explicit about ports, volumes, and env so replacement and recovery are predictable.
+
+### Hooks
+
+- Use hooks for narrow operational tasks, not for hiding application behavior.
+- Fail fast on non-zero exit status.
+- Prefer hooks for deploy notifications, preflight checks, or controlled maintenance steps.
+
+### Builders and registry
+
+- Be explicit about target architecture when local and server architectures differ.
+- Use a remote builder when local builds are too slow or incompatible.
+- Keep registry auth and build secrets out of the Dockerfile and out of git.
+
+## Rails-specific guidance
+
+- Pair deploy changes with app-layer changes that affect startup, migrations, assets, or worker shutdown.
+- Treat migrations as deploy choreography, not just schema edits.
+- If a Rails change adds a new long-running process, background queue, or extra dependency, update Kamal roles and accessories in the same change.
+- Keep worker shutdown behavior in mind for Solid Queue or other job processors.
+
+## Commands you can use
+
+```bash
+bundle add kamal
+bin/kamal init
+bin/kamal setup
+bin/kamal deploy
+bin/kamal rollback
+bin/kamal app exec --interactive "bin/rails console"
+bin/kamal app logs
+```
+
+## Boundaries
+
+### Always
+
+- Keep deploy config repo-owned and reviewable.
+- Use explicit roles, healthchecks, and secrets wiring.
+- Make deploy changes verifiable from commands another engineer can run.
+
+### Ask first
+
+- Multi-region or multi-cluster rollouts.
+- Non-default proxy behavior.
+- Unusual builder or registry topology.
+- Hook logic that mutates application state.
+
+### Never
+
+- Smuggle secrets into committed files.
+- Hide critical deploy behavior in undocumented shell one-liners.
+- Treat Kamal config as optional when the Rails change clearly affects runtime behavior.

--- a/plugins/rails-37signals-patterns/skills/37signals-kamal/agents/openai.yaml
+++ b/plugins/rails-37signals-patterns/skills/37signals-kamal/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "37signals Kamal"
+  short_description: "Deploys Rails applications with Kamal using roles, accessories, hooks, secrets, and deploy-safe operational patterns."
+  default_prompt: "Use $37signals-kamal when setting up Kamal, editing deploy config, shipping Rails changes, or debugging deploy and runtime issues."
+
+policy:
+  allow_implicit_invocation: true

--- a/plugins/rails-37signals-patterns/skills/37signals-multi-tenant/SKILL.md
+++ b/plugins/rails-37signals-patterns/skills/37signals-multi-tenant/SKILL.md
@@ -20,6 +20,8 @@ metadata:
 
 You are an expert Rails developer who implements URL-based multi-tenancy following modern Rails codebases. You build secure, account-scoped applications where every resource belongs to an account and URLs explicitly show the account context.
 
+This skill is for shared-database tenancy. Use `37signals-active-record-tenanted` instead when each tenant should live in its own database and runtime context.
+
 ## Philosophy: URL-Based Multi-Tenancy, Not Subdomain or Schema
 
 **Approach:**

--- a/plugins/rails-37signals-patterns/skills/37signals-refactoring/SKILL.md
+++ b/plugins/rails-37signals-patterns/skills/37signals-refactoring/SKILL.md
@@ -35,6 +35,8 @@ Historical `@...-agent` references map to the local `37signals-*` skills in this
    - React or custom AJAX where Turbo fits
    - RSpec and factories where Minitest and fixtures are preferred
    - Redis-era infrastructure that Rails now replaces directly
+   - drift between shared-database and separate-database tenancy patterns
+   - deploy configuration that no longer matches the app runtime
 2. Choose an incremental migration path.
 3. Protect behavior with tests before large moves.
 4. Refactor one concern at a time.
@@ -49,6 +51,8 @@ Historical `@...-agent` references map to the local `37signals-*` skills in this
 - `$37signals-turbo` and `$37signals-stimulus` when simplifying frontend complexity.
 - `$37signals-test` for migration-safe coverage.
 - `$37signals-caching`, `$37signals-jobs`, `$37signals-events`, and `$37signals-mailer` for infrastructure cleanup.
+- `$37signals-active-record-tenanted` or `$37signals-multi-tenant` for tenancy cleanup.
+- `$37signals-kamal` when runtime roles, secrets, or deploy config need to change with the refactor.
 
 ## Refactoring Rules
 
@@ -65,6 +69,7 @@ Historical `@...-agent` references map to the local `37signals-*` skills in this
 - Replace custom AJAX flows with Turbo-first interactions.
 - Collapse unnecessary API/framework complexity into normal Rails controllers and views.
 - Remove infrastructure carried forward from older Rails assumptions when Rails now has a simpler built-in answer.
+- Untangle mixed tenancy patterns so the code stops switching between `Current.account` and `with_tenant`.
 
 ## Boundaries
 

--- a/plugins/rails-37signals-workflows/skills/rails-37signals-implement/SKILL.md
+++ b/plugins/rails-37signals-workflows/skills/rails-37signals-implement/SKILL.md
@@ -22,15 +22,16 @@ Use this skill for end-to-end feature work in a Rails app that follows 37signals
 - Prefer rich models over `app/services/`.
 - Prefer CRUD resources over custom controller actions.
 - Model business state as records, not booleans, when the state has lifecycle or audit value.
-- Scope reads and writes through `Current.account` in multi-tenant apps.
+- Choose the tenancy model explicitly: shared database with `Current.account`, or separate databases with `with_tenant`.
 - Prefer Hotwire and server-rendered Rails over client-side stateful frontends.
 - Prefer Minitest with fixtures when the codebase follows that stack.
+- Include deploy/runtime work when the feature changes startup, workers, dependencies, or secrets.
 
 ## Implementation Workflow
 
 ### 1. Frame the change
 
-- List the schema changes, domain objects, controller endpoints, views, async work, and tests that will move.
+- List the schema changes, tenancy model, domain objects, controller endpoints, views, async work, deploy/runtime changes, and tests that will move.
 - If the request suggests a state transition like archive, publish, close, or approve, consider a separate resource first.
 
 ### 2. Build from the bottom up
@@ -50,7 +51,7 @@ Use this skill for end-to-end feature work in a Rails app that follows 37signals
 ### 4. Verify
 
 - Run targeted tests first, then broader verification only if needed.
-- Check naming, account scoping, fixture references, and Turbo response behavior.
+- Check naming, tenancy consistency, fixture references, Turbo response behavior, and deploy/runtime impact.
 
 ## Load These References When Needed
 

--- a/plugins/rails-37signals-workflows/skills/rails-37signals-implement/references/conventions.md
+++ b/plugins/rails-37signals-workflows/skills/rails-37signals-implement/references/conventions.md
@@ -10,12 +10,14 @@ Source adapted from `ThibautBaissac/rails_ai_agents` `.claude_37signals`.
 - Prefer ERB plus Turbo plus Stimulus over React or Vue for standard Rails work.
 - Keep jobs shallow: enqueue from models or callbacks, perform by calling model methods.
 - Keep mailers minimal and transactional.
+- Treat Kamal as the default deploy/runtime layer when the app is deployed with modern Rails conventions.
 
 ## Data and multi-tenancy
 
 - Use UUID-style identifiers where the app already leans that direction.
-- Put `account_id` on tenant-owned records.
-- Scope through `Current.account` instead of broad `Model.find` or `Model.where`.
+- Choose one tenancy model deliberately:
+  - shared DB: put `account_id` on tenant-owned records and scope through `Current.account`
+  - separate DB: use `tenanted` plus `with_tenant` and keep shared data on a non-tenanted connection
 - Avoid default scopes for tenancy when explicit scoping is clearer.
 
 ## Model and controller heuristics

--- a/plugins/rails-37signals-workflows/skills/rails-37signals-implement/references/implementation-workflow.md
+++ b/plugins/rails-37signals-workflows/skills/rails-37signals-implement/references/implementation-workflow.md
@@ -5,11 +5,13 @@ Source adapted from the upstream `implement-agent.md` and shared 37signals rules
 ## Preferred sequence
 
 1. Database
-2. Models and concerns
-3. Controllers and routes
-4. Views, Turbo, and Stimulus
-5. Jobs and mailers
-6. Tests
+2. Tenancy and runtime shape
+3. Models and concerns
+4. Controllers and routes
+5. Views, Turbo, and Stimulus
+6. Jobs and mailers
+7. Deploy/runtime config
+8. Tests
 
 ## Per-layer guidance
 
@@ -18,6 +20,11 @@ Source adapted from the upstream `implement-agent.md` and shared 37signals rules
 - Add the table or columns before writing dependent code.
 - Prefer simple, reversible migrations.
 - Add tenant and lookup indexes that match real query patterns.
+
+### Tenancy and runtime shape
+
+- Decide whether the feature belongs in shared-database tenancy or database-per-tenant tenancy.
+- If the change adds workers, accessories, secrets, or startup requirements, capture the Kamal/runtime impact before coding the app layers.
 
 ### Models
 
@@ -42,6 +49,11 @@ Source adapted from the upstream `implement-agent.md` and shared 37signals rules
 - Put durable logic on the model and let the job call it.
 - Prefer async delivery or processing for slow work.
 
+### Deploy/runtime config
+
+- Update deploy config when the app shape changes.
+- Keep roles, healthchecks, secrets, and accessories aligned with the code you just added.
+
 ### Tests
 
 - Add or update model, controller, and system tests based on the surface area changed.
@@ -52,3 +64,4 @@ Source adapted from the upstream `implement-agent.md` and shared 37signals rules
 - New resource or custom action: choose the new resource if the change has its own lifecycle.
 - Model method or service object: choose the model method unless the codebase already has a justified service boundary.
 - Sync or async: choose async when the work is slow, retryable, or external.
+- Shared DB or separate DB tenancy: choose the model first, then keep every layer consistent with it.

--- a/plugins/rails-37signals-workflows/skills/rails-37signals-refactor/SKILL.md
+++ b/plugins/rails-37signals-workflows/skills/rails-37signals-refactor/SKILL.md
@@ -32,7 +32,8 @@ Use this skill when the goal is not a brand-new feature, but a safer path from a
 - Fat controllers to CRUD resources plus model methods.
 - RSpec or FactoryBot-heavy tests toward Minitest plus fixtures when the repo is already moving there.
 - Sidekiq or Redis-specific background work toward Rails-native queueing patterns.
-- Missing tenant scoping toward explicit `Current.account` access.
+- Mixed or missing tenancy toward one explicit model: `Current.account` for shared DB or `with_tenant` for separate DB.
+- Runtime drift toward explicit deploy config that matches the app’s current worker and dependency shape.
 
 ## Workflow
 

--- a/plugins/rails-37signals-workflows/skills/rails-37signals-refactor/references/conventions.md
+++ b/plugins/rails-37signals-workflows/skills/rails-37signals-refactor/references/conventions.md
@@ -10,6 +10,7 @@ Source adapted from `ThibautBaissac/rails_ai_agents` `.claude_37signals`.
 - State transitions become resources when the state matters in its own right.
 - Jobs call model methods instead of embedding business rules.
 - Views stay server-rendered, with Turbo and small Stimulus controllers where needed.
+- Deploy config should match the current app runtime instead of lagging behind it.
 
 ## Refactoring signals
 
@@ -17,6 +18,8 @@ Source adapted from `ThibautBaissac/rails_ai_agents` `.claude_37signals`.
 - Controllers own business logic or multi-step workflows.
 - Boolean flags encode business lifecycle.
 - Queries ignore tenant boundaries.
+- The code mixes `Current.account` assumptions with database-per-tenant code.
+- Worker or deploy config no longer matches the runtime the app now needs.
 - The test stack is slow or over-isolated for normal Rails workflows.
 
 ## Style reminders

--- a/plugins/rails-37signals-workflows/skills/rails-37signals-refactor/references/refactoring-guide.md
+++ b/plugins/rails-37signals-workflows/skills/rails-37signals-refactor/references/refactoring-guide.md
@@ -34,8 +34,20 @@ Source adapted from the upstream `refactoring-agent.md`.
 - Keep the job shallow.
 - Move durable logic onto the model or a stable domain boundary.
 
+### Tenancy cleanup
+
+- Pick one tenancy model for the affected area before refactoring around it.
+- Shared-database refactors should converge on `Current.account` plus explicit account scoping.
+- Separate-database refactors should converge on `tenanted` plus `with_tenant`.
+
+### Runtime cleanup
+
+- When the refactor changes workers, env vars, or dependencies, update deploy/runtime config in the same change.
+- Remove stale role commands or secrets wiring once the new runtime path is proven.
+
 ## Risk management
 
 - Use staged deployments for data shape changes.
+- Pair app refactors with Kamal/runtime changes when startup or process topology changes.
 - Use deprecation warnings when public interfaces move.
 - Prefer compatibility layers over sudden removals when external callers may exist.

--- a/scripts/install-codex-assets.ps1
+++ b/scripts/install-codex-assets.ps1
@@ -1,5 +1,4 @@
 #!/usr/bin/env pwsh
-$ErrorActionPreference = "Stop"
 
 param(
   [string]$RepoPath = "$HOME/src/agent-skills",
@@ -14,6 +13,8 @@ param(
   [switch]$Force,
   [switch]$Help
 )
+
+$ErrorActionPreference = "Stop"
 
 function Show-Usage {
   @"

--- a/skills/37signals-kamal
+++ b/skills/37signals-kamal
@@ -1,0 +1,1 @@
+../plugins/rails-37signals-patterns/skills/37signals-kamal


### PR DESCRIPTION
## Summary

This refresh tightens the Rails / 37signals section around current repo truth instead of adding more bulk.

The main changes are:
- add a new `37signals-kamal` specialist so deployment and runtime operations are first-class Rails skills instead of implied background knowledge
- strengthen `37signals-active-record-tenanted` with clearer database-per-tenant boundaries, tenant lifecycle guidance, and more honest caveats about still-evolving upstream integrations
- update the implement/refactor orchestration skills and references so they force an explicit tenancy choice and include deploy/runtime impact in normal Rails work
- refresh README and plugin/catalog metadata so discovery surfaces the new Kamal coverage
- rebuild generated views and validate the repo structure

## Why

The repo already moved to a plugin-first source model in PR #9 and started normalizing the heaviest 37signals skills, but the Rails area still had two gaps:

1. Kamal was materially underrepresented despite being part of the modern Rails stack.
2. The repo mixed shared-database and separate-database tenancy guidance without a strong enough decision boundary.

This change fixes both without trying to rewrite the entire Rails catalog.

## Validation

- `python3 scripts/build_marketplaces.py`
- `python3 scripts/build_runtime_views.py`
- `bin/check`

## Notes

This PR also adds the missing `agents/openai.yaml` for `37signals-active-record-tenanted` so that skill is consistent with the rest of the pattern plugin.