### PR TITLE
[codex] Filter Dagger MCP stdout for strict clients

### DIFF
--- a/plugins/rcc/skills/rcc/references/dagger-mcp.md
+++ b/plugins/rcc/skills/rcc/references/dagger-mcp.md
@@ -23,6 +23,11 @@ Do not force a repo path unless the user asks for a fixed module. If the user wa
 
 No-module mode is privileged by Dagger design. Treat it as host/Docker-capable, not a harmless read-only helper.
 
+The launcher filters Dagger's stdio stream for strict MCP clients. Dagger `mcp`
+can emit engine progress lines on stdout before JSON-RPC responses even with
+`--silent`; those lines are forwarded to stderr, while JSON-RPC lines remain on
+stdout.
+
 ## Codex Registration
 
 On Josh's Bluefin host, prefer current-directory registration:

--- a/plugins/rcc/skills/rcc/scripts/rcc-dagger-mcp
+++ b/plugins/rcc/skills/rcc/scripts/rcc-dagger-mcp
@@ -27,10 +27,16 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
 if ! command -v dagger >/dev/null 2>&1; then
   echo "dagger CLI is required to expose the RCC Dagger module as MCP." >&2
   exit 127
 fi
+
+run_dagger_mcp() {
+  python3 "$script_dir/rcc-dagger-mcp-filter.py" "$@"
+}
 
 rcc_repo="${RCC_DAGGER_REPO:-${RCC_DAGGER_MODULE:-}}"
 if [[ -z "$rcc_repo" && -f dagger.json && -d .dagger ]]; then
@@ -38,7 +44,8 @@ if [[ -z "$rcc_repo" && -f dagger.json && -d .dagger ]]; then
 fi
 
 if [[ -z "$rcc_repo" ]]; then
-  exec dagger --silent mcp --stdio --no-mod --env-privileged "$@"
+  run_dagger_mcp --no-mod --env-privileged "$@"
+  exit $?
 fi
 
 rcc_repo="$(python3 - "$rcc_repo" <<'PY'
@@ -54,4 +61,4 @@ if [[ ! -f "$rcc_repo/dagger.json" || ! -d "$rcc_repo/.dagger" ]]; then
   exit 2
 fi
 
-exec dagger --silent mcp --stdio --mod "$rcc_repo" "$@"
+run_dagger_mcp --mod "$rcc_repo" "$@"

--- a/plugins/rcc/skills/rcc/scripts/rcc-dagger-mcp-filter.py
+++ b/plugins/rcc/skills/rcc/scripts/rcc-dagger-mcp-filter.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Run `dagger mcp` with a clean MCP stdout stream."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+
+
+def main() -> int:
+    cmd = ["dagger", "--silent", "mcp", "--stdio", *sys.argv[1:]]
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    def forward_signal(signum: int, _frame: object) -> None:
+        if proc.poll() is None:
+            proc.send_signal(signum)
+
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(signum, forward_signal)
+
+    def copy_stdin() -> None:
+        try:
+            while True:
+                chunk = os.read(sys.stdin.fileno(), 65536)
+                if not chunk:
+                    break
+                proc.stdin.write(chunk)
+                proc.stdin.flush()
+        finally:
+            try:
+                proc.stdin.close()
+            except BrokenPipeError:
+                pass
+
+    def copy_stderr() -> None:
+        for line in proc.stderr:
+            sys.stderr.buffer.write(line)
+            sys.stderr.buffer.flush()
+
+    threading.Thread(target=copy_stdin, daemon=True).start()
+    threading.Thread(target=copy_stderr, daemon=True).start()
+
+    marker = b'{"jsonrpc"'
+    buffer = b""
+
+    while True:
+        chunk = os.read(proc.stdout.fileno(), 65536)
+        if not chunk:
+            break
+        buffer += chunk
+
+        while buffer:
+            json_start = buffer.find(marker)
+            if json_start == -1:
+                flush_len = max(0, len(buffer) - len(marker) + 1)
+                if flush_len:
+                    sys.stderr.buffer.write(buffer[:flush_len])
+                    sys.stderr.buffer.flush()
+                    buffer = buffer[flush_len:]
+                break
+
+            if json_start:
+                sys.stderr.buffer.write(buffer[:json_start])
+                sys.stderr.buffer.flush()
+                buffer = buffer[json_start:]
+
+            newline = buffer.find(b"\n")
+            if newline == -1:
+                break
+
+            sys.stdout.buffer.write(buffer[: newline + 1])
+            sys.stdout.buffer.flush()
+            buffer = buffer[newline + 1 :]
+
+    if buffer:
+        if buffer.startswith(marker):
+            sys.stdout.buffer.write(buffer)
+            sys.stdout.buffer.flush()
+        else:
+            sys.stderr.buffer.write(buffer)
+            sys.stderr.buffer.flush()
+
+    return proc.wait()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Keep the RCC Dagger MCP launcher cwd-first, but route it through a small stdio filter.
- Move Dagger engine progress emitted on stdout to stderr so strict MCP clients receive clean JSON-RPC on stdout.
- Document why the filter exists and how it relates to Dagger `mcp --stdio`.

## Root Cause

`dagger mcp --stdio` can emit engine progress lines on stdout before JSON-RPC responses, even with `--silent`. Lenient MCP transports can ignore non-JSON lines, but stricter clients can treat the startup stream as invalid MCP output.

## Test Plan

- `bash -n plugins/rcc/skills/rcc/scripts/rcc-dagger-mcp`
- `python3 -m py_compile plugins/rcc/skills/rcc/scripts/rcc-dagger-mcp-filter.py`
- `python3 scripts/validate_repo.py`
- `python3 scripts/build_runtime_views.py --check`
- Direct MCP initialize smoke test against the registered launcher: stdout begins with JSON-RPC, Dagger progress appears on stderr.

`pytest` was not run because the host Python in this Bluefin session does not have `pytest` installed.
